### PR TITLE
Handle empty icon value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protonapp/react-native-material-ui",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "React Native Material Design Components",
   "main": "./index.js",
   "scripts": {

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -38,9 +38,8 @@ const defaultProps = {
   iconSet: null,
 };
 
-const isURL = value => {
-  value.startsWith('https://');
-};
+const isURL = value =>
+  value && typeof value === 'string' && value.startsWith('https://');
 
 const getIconComponent = iconSet => {
   switch (iconSet) {


### PR DESCRIPTION
## Problem
We are treating all icon values as strings when there's a chance it could be empty.

## Solution
Check if icon value is a string before checking `startsWith`.